### PR TITLE
olorenchemengine

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ A curated list of awesome Cheminformatics software, resources, and libraries. Mo
 
 * [DeepChem](https://github.com/deepchem/deepchem) - Deep learning library for Chemistry based on Tensorflow
 * [ChemML](https://github.com/hachmannlab/chemml) - ChemML is a machine learning and informatics program suite for the analysis, mining, and modeling of chemical and materials data. (based on Tensorflow)
+* [olorenchemengine](https://github.com/Oloren-AI/olorenchemengine) - Molecular property prediction with unified API for diverse models and respresentations,
+  with integrated uncertainty quantification, interpretability, and hyperparameter/architecture tuning.
 * [OpenChem](https://github.com/Mariewelt/OpenChem) - OpenChem is a deep learning toolkit for Computational Chemistry with PyTorch backend.
 * [chainer-chemistry](https://github.com/pfnet-research/chainer-chemistry) - A Library for Deep Learning in Biology and Chemistry.
 * [pytorch-geometric](https://pytorch-geometric.readthedocs.io/en/latest/) - A PyTorch library provides implementation of many graph convolution algorithms.


### PR DESCRIPTION
Oloren ChemEngine (oce) is a software package developed and maintained by Oloren AI containing a unified API for the development and use of molecular property predictors enabling

Direct development of high-performing predictors
Integration of predictors into model interpretability, uncertainty quantification, and analysis frameworks
Here's an example of what we mean by this. In less than ten lines of code, we'll train, save, load, and predict with a gradient-boosted model with two different molecular vector representations.
```python
import olorenchemengine as oce

df = oce.ExampleDataFrame()

model = oce.BaseBoosting([
            oce.RandomForestModel(oce.DescriptastorusDescriptor("rdkit2dnormalized"), n_estimators=1000),
            oce.RandomForestModel(oce.OlorenCheckpoint("default"), n_estimators=1000)])
model.fit(df["Smiles"], df["pChEMBL Value"])

oce.save(model, "model.oce")

model2 = oce.load("model.oce")

y_pred = model2.predict(["CC(=O)OC1=CC=CC=C1C(=O)O"])
```
It's that simple! And it's just as simple to train a graph neural network, generate visualizations, and create error models. More information on features and capabilities is available in our documentation at [docs.oloren.ai](https://docs.oloren.ai/).