### PR TITLE
Add ChemInformant to Web APIs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ A curated list of awesome Cheminformatics software, resources, and libraries. Mo
 * [CIRpy](http://cirpy.readthedocs.org/) - Python wrapper for the [NCI Chemical Identifier Resolver (CIR)](https://cactus.nci.nih.gov/chemical/structure).
 * [Beaker](https://github.com/chembl/chembl_beaker) - [RDKit](http://www.rdkit.org/) and [OSRA](https://cactus.nci.nih.gov/osra/) in the [Bottle](http://bottlepy.org/docs/dev/) on [Tornado](http://www.tornadoweb.org/en/stable/).
 * [chemminetools](https://github.com/girke-lab/chemminetools) - Open source web framework for small molecule analysis based on Django.
-* [ambit](http://ambit.sourceforge.net/) - offers chemoinformatics functionality via REST web services.
+* [ambit](http://ambit.sourceforge.net/) - Offers chemoinformatics functionality via REST web services.
+* [ChemInformant](https://github.com/HzaCode/ChemInformant) - High-throughput cheminformatics toolkit for large-batch retrieval/curation and descriptor & substructure pipelines; CLI+API; RDKit/DeepChem compatible. [ [paper](https://joss.theoj.org/papers/10.21105/joss.08341) | [web](https://hezhiang.com/cheminformant_real.html) ]
 
 <a id="lib-db"></a>
 ### Databases


### PR DESCRIPTION
This PR adds [ChemInformant](https://github.com/HzaCode/ChemInformant) to the **Web APIs** section.

**Why ChemInformant is awesome:**
- High-throughput design: built for large-batch retrieval and curation from PubChem, going beyond simple wrappers.  
- Dual interface: both Python API and CLI, making it easy to integrate into pipelines and shell workflows.  
- Downstream ready: provides descriptor calculation, substructure search, and dataset curation pipelines that plug into RDKit/DeepChem.  
- Research-grade: peer-reviewed and published in JOSS ([paper](https://joss.theoj.org/papers/10.21105/joss.08341)), ensuring documentation, testing, and long-term maintainability.  

This complements existing tools like ChemSpiPy by focusing on scalable workflows and dataset-level automation rather than single-compound lookups.
