### PR TITLE
Add USDA Phytochemical Database (enriched with ClinicalTrials + ChEMBL + patent data)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ A curated list of awesome Cheminformatics software, resources, and libraries. Mo
 
 * [razi](https://github.com/rvianello/razi) - Cheminformatic extension for the SQLAlchemy database.
 * [Chemical Translation Service](https://bitbucket.org/fiehnlab/fiehnlab-cts/src/master/) - Source code of the [Chemical Translation Service](https://cts.fiehnlab.ucdavis.edu/) web service.
-* [USDA Phytochemical Database — Enriched v2.0 (sample)](https://github.com/wirthal1990-tech/USDA-Phytochemical-Database-JSON) - Freely available CC BY-NC sample of an enriched USDA phytochemical database (JSON + Parquet) linking phytochemicals to plant species with PubMed, ClinicalTrials.gov, ChEMBL bioactivity, and USPTO patent annotations.
+* [USDA Phytochemical Database — Enriched v2.0 (sample)](https://github.com/wirthal1990-tech/USDA-Phytochemical-Database-JSON) - Freely available CC BY-NC 4.0 sample of an enriched USDA phytochemical database (JSON + Parquet) linking phytochemicals to plant species with PubMed, ClinicalTrials.gov, ChEMBL bioactivity, and USPTO patent annotations.
 
 <a id="lib-dock"></a>
 ### Docking

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ A curated list of awesome Cheminformatics software, resources, and libraries. Mo
 
 * [razi](https://github.com/rvianello/razi) - Cheminformatic extension for the SQLAlchemy database.
 * [Chemical Translation Service](https://bitbucket.org/fiehnlab/fiehnlab-cts/src/master/) - Source code of the [Chemical Translation Service](https://cts.fiehnlab.ucdavis.edu/) web service.
+* [USDA Phytochemical Database — Enriched v2.0](https://github.com/wirthal1990-tech/USDA-Phytochemical-Database-JSON) - 104K records linking 24,771 phytochemicals to 2,315 plant species with PubMed, ClinicalTrials.gov, ChEMBL bioactivity, and USPTO patent enrichment. JSON + Parquet. Free 400-row sample.
 
 <a id="lib-dock"></a>
 ### Docking

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ A curated list of awesome Cheminformatics software, resources, and libraries. Mo
 
 * [razi](https://github.com/rvianello/razi) - Cheminformatic extension for the SQLAlchemy database.
 * [Chemical Translation Service](https://bitbucket.org/fiehnlab/fiehnlab-cts/src/master/) - Source code of the [Chemical Translation Service](https://cts.fiehnlab.ucdavis.edu/) web service.
-* [USDA Phytochemical Database — Enriched v2.0](https://github.com/wirthal1990-tech/USDA-Phytochemical-Database-JSON) - 104K records linking 24,771 phytochemicals to 2,315 plant species with PubMed, ClinicalTrials.gov, ChEMBL bioactivity, and USPTO patent enrichment. JSON + Parquet. Free 400-row sample.
+* [USDA Phytochemical Database — Enriched v2.0 (sample)](https://github.com/wirthal1990-tech/USDA-Phytochemical-Database-JSON) - Freely available CC BY-NC sample of an enriched USDA phytochemical database (JSON + Parquet) linking phytochemicals to plant species with PubMed, ClinicalTrials.gov, ChEMBL bioactivity, and USPTO patent annotations.
 
 <a id="lib-dock"></a>
 ### Docking


### PR DESCRIPTION
This dataset restructures and enriches the USDA Dr. Duke's Phytochemical & Ethnobotanical Database into a flat, ML-ready format with 8 columns:

- chemical, plant_species, application, dosage
- pubmed_mentions_2026, clinical_trials_count_2026, chembl_bioactivity_count, patent_count_since_2020

Useful for virtual screening, lead prioritisation, and ethnopharmacology research. Free 400-row sample available (CC BY-NC 4.0), full dataset commercial.